### PR TITLE
CI: Align workflows and Dependabot with template

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,7 +17,7 @@ indent_size = 2
 max_line_length = 80
 
 [*.py]
-max_line_legth = 120
+max_line_length = 120
 
 [*.sh]
 max_line_length = 80

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
     schedule:
       interval: "weekly"
     commit-message:
-      prefix: "Chore"
+      prefix: "CI(actions)"
+    # Wait before opening a bump PR so we don't churn on a release
+    # that gets retracted or superseded shortly after it ships.
+    # This is required to satisfy the zizmor workflow auditing tool.
     cooldown:
       default-days: 7
+    open-pull-requests-limit: 15

--- a/.github/workflows/clear-action-cache.yaml
+++ b/.github/workflows/clear-action-cache.yaml
@@ -1,0 +1,317 @@
+---
+# SPDX-FileCopyrightText: 2025 The Linux Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+name: 'Clear Action Cache 🧹'
+
+# yamllint disable-line rule:truthy
+on:
+  workflow_dispatch:
+    inputs:
+      key_pattern:
+        description: >-
+          Optional substring filter applied to cache keys. Leave
+          empty to remove every cache entry.
+        required: false
+        default: ''
+        type: string
+      ref_filter:
+        description: >-
+          Optional git ref to limit deletion to (e.g.
+          'refs/heads/main' or 'refs/pull/42/merge'). Leave empty
+          to ignore the ref attribute.
+        required: false
+        default: ''
+        type: string
+      dry_run:
+        description: >-
+          When 'true', list matching entries but do not delete
+          them.
+        required: false
+        default: 'false'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  clear-cache:
+    name: 'Clear Action Cache'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      # Actions cache deletion requires the actions: write scope.
+      actions: write
+    steps:
+      # Load the egress allow-list out-of-band from the
+      # organisation's .github repository and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below.
+      # yamllint disable-line rule:line-length
+      - uses: lfreleng-actions/harden-runner-block-action@42663a22f7abe31521cbc6120901353a4b2849bc  # v0.2.0
+        with:
+          config: '@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+        with:
+          egress-policy: 'block'
+          allowed-endpoints: >
+            ${{ env.CONNECTION_ALLOW_LIST }}
+
+      - name: 'Inspect cache before deletion'
+        id: before
+        env:
+          GH_TOKEN: ${{ github.token }}
+          KEY_PATTERN: ${{ inputs.key_pattern }}
+          REF_FILTER: ${{ inputs.ref_filter }}
+        run: |
+          # List current cache entries (pre-deletion snapshot).
+          set -euo pipefail
+
+          echo "Repository: ${{ github.repository }}"
+          echo "Key filter: '${KEY_PATTERN:-<none>}'"
+          echo "Ref filter: '${REF_FILTER:-<none>}'"
+          echo ""
+
+          # Page through all caches via the REST API; gh cache list
+          # is convenient locally but the JSON response from the
+          # REST endpoint is more reliable for scripting.
+          all_caches=$(
+            gh api \
+              --paginate \
+              -H "Accept: application/vnd.github+json" \
+              "/repos/${{ github.repository }}/actions/caches?per_page=100" \
+              --jq '.actions_caches[]'
+          )
+
+          if [ -z "$all_caches" ]; then
+            echo "No cache entries found."
+            echo "before_count=0" >> "$GITHUB_OUTPUT"
+            echo "matched_count=0" >> "$GITHUB_OUTPUT"
+            : > matched_ids.txt
+            exit 0
+          fi
+
+          # Total count before any filtering.
+          before_count=$(printf '%s\n' "$all_caches" | jq -s 'length')
+          echo "Total cache entries: $before_count"
+
+          # Apply optional key/ref filters.
+          filtered=$(printf '%s\n' "$all_caches" | jq -c '.')
+          if [ -n "$KEY_PATTERN" ]; then
+            filtered=$(printf '%s\n' "$filtered" | jq -c \
+              --arg pat "$KEY_PATTERN" \
+              'select(.key | contains($pat))')
+          fi
+          if [ -n "$REF_FILTER" ]; then
+            filtered=$(printf '%s\n' "$filtered" | jq -c \
+              --arg ref "$REF_FILTER" \
+              'select(.ref == $ref)')
+          fi
+
+          if [ -z "$filtered" ]; then
+            echo "No cache entries match the supplied filters."
+            echo "before_count=$before_count" >> "$GITHUB_OUTPUT"
+            echo "matched_count=0" >> "$GITHUB_OUTPUT"
+            : > matched_ids.txt
+            exit 0
+          fi
+
+          matched_count=$(printf '%s\n' "$filtered" | jq -s 'length')
+          echo ""
+          echo "Matched $matched_count cache entr(y/ies) for processing:"
+          printf '%s\n' "$filtered" | jq -r \
+            '"  - id=\(.id)  size=\(.size_in_bytes)B  ref=\(.ref)  key=\(.key)"'
+
+          # Persist matched IDs for the deletion step.
+          printf '%s\n' "$filtered" | jq -r '.id' > matched_ids.txt
+
+          {
+            echo "## Cache snapshot (before)"
+            echo ""
+            echo "| Property | Value |"
+            echo "|----------|-------|"
+            echo "| Total entries | $before_count |"
+            echo "| Matched | $matched_count |"
+            echo "| Dry run | \`${{ inputs.dry_run }}\` |"
+            echo ""
+            # Render user-controlled filter inputs inside a fenced
+            # code block. KEY_PATTERN and REF_FILTER are free-form
+            # workflow_dispatch inputs and may contain characters
+            # (|, backticks, newlines) that would break table
+            # rendering or inject markup into the step summary.
+            # jq @json safely quotes/escapes the values.
+            echo "### Filters"
+            echo ""
+            echo '```text'
+            jq -nr \
+              --arg key "${KEY_PATTERN:-}" \
+              --arg ref "${REF_FILTER:-}" \
+              '"key_pattern=\($key|@json)\nref_filter=\($ref|@json)"'
+            echo '```'
+            echo ""
+            if [ "$matched_count" -gt 0 ]; then
+              echo "### Matched entries"
+              echo ""
+              # Emit as a fenced code block rather than a Markdown
+              # table: cache keys and refs are user-controlled and
+              # may contain characters (|, backticks, newlines) that
+              # would otherwise break table rendering or allow
+              # injection into the step summary.
+              echo '```text'
+              printf '%s\n' "$filtered" | jq -r '
+                  "id=\(.id)  size=\(.size_in_bytes)B  " +
+                  "ref=\(.ref|tojson)  key=\(.key|tojson)"
+                '
+              echo '```'
+              echo ""
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          echo "before_count=$before_count" >> "$GITHUB_OUTPUT"
+          echo "matched_count=$matched_count" >> "$GITHUB_OUTPUT"
+
+      - name: 'Delete matching cache entries'
+        if: steps.before.outputs.matched_count != '0'
+        id: delete
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          # Delete the matched cache IDs unless this is a dry run.
+          set -euo pipefail
+
+          if [ ! -s matched_ids.txt ]; then
+            echo "No matched IDs file; nothing to delete."
+            echo "deleted_count=0" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "Dry-run mode: would delete the following IDs:"
+            cat matched_ids.txt
+            echo "deleted_count=0" >> "$GITHUB_OUTPUT"
+            {
+              echo "### Dry run"
+              echo ""
+              echo "No entries were deleted."
+              echo ""
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          deleted=0
+          failed=0
+          while IFS= read -r cache_id; do
+            [ -z "$cache_id" ] && continue
+            echo "Deleting cache id=$cache_id…"
+            if gh api \
+                --method DELETE \
+                -H "Accept: application/vnd.github+json" \
+                "/repos/${{ github.repository }}/actions/caches/${cache_id}";
+            then
+              deleted=$((deleted + 1))
+            else
+              echo "::warning::Failed to delete cache id=$cache_id"
+              failed=$((failed + 1))
+            fi
+          done < matched_ids.txt
+
+          echo ""
+          echo "Deleted: $deleted"
+          echo "Failed:  $failed"
+          echo "deleted_count=$deleted" >> "$GITHUB_OUTPUT"
+          echo "failed_count=$failed" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "### Deletion result"
+            echo ""
+            echo "| Property | Value |"
+            echo "|----------|-------|"
+            echo "| Deleted | $deleted |"
+            echo "| Failed | $failed |"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$failed" -gt 0 ]; then
+            exit 1
+          fi
+
+      - name: 'Verify cache after deletion'
+        if: always() && steps.before.outputs.matched_count != '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          KEY_PATTERN: ${{ inputs.key_pattern }}
+          REF_FILTER: ${{ inputs.ref_filter }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          # Re-query the cache list and confirm matched entries are
+          # gone (or still present in dry-run mode).
+          set -euo pipefail
+
+          all_caches=$(
+            gh api \
+              --paginate \
+              -H "Accept: application/vnd.github+json" \
+              "/repos/${{ github.repository }}/actions/caches?per_page=100" \
+              --jq '.actions_caches[]'
+          )
+
+          after_count=0
+          if [ -n "$all_caches" ]; then
+            after_count=$(printf '%s\n' "$all_caches" | jq -s 'length')
+          fi
+
+          remaining_matches=0
+          if [ -n "$all_caches" ]; then
+            filtered=$(printf '%s\n' "$all_caches" | jq -c '.')
+            if [ -n "$KEY_PATTERN" ]; then
+              filtered=$(printf '%s\n' "$filtered" | jq -c \
+                --arg pat "$KEY_PATTERN" \
+                'select(.key | contains($pat))')
+            fi
+            if [ -n "$REF_FILTER" ]; then
+              filtered=$(printf '%s\n' "$filtered" | jq -c \
+                --arg ref "$REF_FILTER" \
+                'select(.ref == $ref)')
+            fi
+            if [ -n "$filtered" ]; then
+              remaining_matches=$(
+                printf '%s\n' "$filtered" | jq -s 'length'
+              )
+            fi
+          fi
+
+          echo "Total cache entries after run: $after_count"
+          echo "Remaining matches:             $remaining_matches"
+
+          {
+            echo "## Cache snapshot (after)"
+            echo ""
+            echo "| Property | Value |"
+            echo "|----------|-------|"
+            echo "| Total entries | $after_count |"
+            echo "| Remaining matches | $remaining_matches |"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "Dry run: skipping post-deletion verification."
+            exit 0
+          fi
+
+          if [ "$remaining_matches" -ne 0 ]; then
+            echo "::error::Expected zero matching cache entries " \
+              "after deletion, found $remaining_matches"
+            exit 1
+          fi
+
+          echo "✅ All matched cache entries successfully removed"

--- a/.github/workflows/input-validation.yaml
+++ b/.github/workflows/input-validation.yaml
@@ -27,11 +27,22 @@ jobs:
       contents: read
     timeout-minutes: 30
     steps:
-      - name: 'Harden Runner'
+      # Load the egress allow-list out-of-band from the
+      # organisation's .github repository and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below.
+      # yamllint disable-line rule:line-length
+      - uses: lfreleng-actions/harden-runner-block-action@42663a22f7abe31521cbc6120901353a4b2849bc  # v0.2.0
+        with:
+          config: '@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
         # yamllint disable-line rule:line-length
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
         with:
-          egress-policy: audit
+          egress-policy: 'block'
+          allowed-endpoints: >
+            ${{ env.CONNECTION_ALLOW_LIST }}
 
       - name: 'Checkout local action'
         # yamllint disable-line rule:line-length

--- a/.github/workflows/openssf-scorecard.yaml
+++ b/.github/workflows/openssf-scorecard.yaml
@@ -1,0 +1,40 @@
+---
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 The Linux Foundation
+
+# This workflow uses actions that are not certified by GitHub. They are provided
+# by a third-party and are governed by separate terms of service, privacy
+# policy, and support documentation.
+
+name: "OpenSSF Scorecard"
+
+# yamllint disable-line rule:truthy
+on:
+  workflow_dispatch:
+  # For Branch-Protection check. Only the default branch is supported. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
+  branch_protection_rule:
+  # To guarantee Maintained check is occasionally updated. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
+  schedule:
+    - cron: "50 4 * * 0"
+  push:
+    branches: ["main", "master"]
+
+# Declare default permissions as none.
+permissions: {}
+
+jobs:
+  openssf-scorecard:
+    name: "OpenSSF Scorecard"
+    # yamllint disable-line rule:line-length
+    uses: lfit/releng-reusable-workflows/.github/workflows/reuse-openssf-scorecard.yaml@b2adc11cd90f0ca72a34202589a06d374b5d8366  # v0.5.0
+    permissions:
+      # Needed to read repository contents (checkout, etc.).
+      contents: read
+      # Needed to upload the results to the code-scanning dashboard.
+      security-events: write
+      # Needed to publish results and obtain a Scorecard badge via OIDC.
+      id-token: write
+      # Uncomment the permission below if installing in a private repository.
+      # actions: read

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -25,11 +25,22 @@ jobs:
     runs-on: 'ubuntu-latest'
     timeout-minutes: 3
     steps:
-      # Harden the runner used by this workflow
+      # Load the egress allow-list out-of-band from the
+      # organisation's .github repository and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below.
       # yamllint disable-line rule:line-length
-      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+      - uses: lfreleng-actions/harden-runner-block-action@42663a22f7abe31521cbc6120901353a4b2849bc  # v0.2.0
         with:
-          egress-policy: 'audit'
+          config: '@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+        with:
+          egress-policy: 'block'
+          allowed-endpoints: >
+            ${{ env.CONNECTION_ALLOW_LIST }}
 
       # yamllint disable-line rule:line-length
       - uses: release-drafter/release-drafter@693d20e7c1ce1a81d3a41962f85914253b518449 # v7.3.1

--- a/.github/workflows/tag-push.yaml
+++ b/.github/workflows/tag-push.yaml
@@ -25,11 +25,22 @@ jobs:
     outputs:
       tag: "${{ steps.tag_validate.outputs.tag_name }}"
     steps:
-      # Harden the runner used by this workflow
+      # Load the egress allow-list out-of-band from the
+      # organisation's .github repository and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below.
       # yamllint disable-line rule:line-length
-      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+      - uses: lfreleng-actions/harden-runner-block-action@42663a22f7abe31521cbc6120901353a4b2849bc  # v0.2.0
         with:
-          egress-policy: audit
+          config: '@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+        with:
+          egress-policy: 'block'
+          allowed-endpoints: >
+            ${{ env.CONNECTION_ALLOW_LIST }}
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
@@ -56,11 +67,22 @@ jobs:
       contents: write
     timeout-minutes: 5
     steps:
-      # Harden the runner used by this workflow
+      # Load the egress allow-list out-of-band from the
+      # organisation's .github repository and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below.
       # yamllint disable-line rule:line-length
-      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+      - uses: lfreleng-actions/harden-runner-block-action@42663a22f7abe31521cbc6120901353a4b2849bc  # v0.2.0
         with:
-          egress-policy: audit
+          config: '@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+        with:
+          egress-policy: 'block'
+          allowed-endpoints: >
+            ${{ env.CONNECTION_ALLOW_LIST }}
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -34,10 +34,22 @@ jobs:
       contents: read
     timeout-minutes: 30
     steps:
-      # Harden the runner used by this workflow
-      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+      # Load the egress allow-list out-of-band from the
+      # organisation's .github repository and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below.
+      # yamllint disable-line rule:line-length
+      - uses: lfreleng-actions/harden-runner-block-action@42663a22f7abe31521cbc6120901353a4b2849bc  # v0.2.0
         with:
-          egress-policy: 'audit'
+          config: '@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+        with:
+          egress-policy: 'block'
+          allowed-endpoints: >
+            ${{ env.CONNECTION_ALLOW_LIST }}
 
       - name: 'Checkout repository'
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3


### PR DESCRIPTION
## Summary

Audit of this repository against the canonical `actions-template`, bringing the
standard GitHub Actions workflows and Dependabot configuration back into line
while preserving repository-specific customisations.

## Workflows

- Convert the `harden-runner` step in `release-drafter`, `tag-push`, `testing`,
  and `input-validation` from the legacy single-step `egress-policy: audit` to
  the current two-step **egress block** pattern, loading the org allow-list
  out-of-band via `harden-runner-block-action`.
- Add the two standard workflows that were missing from this repository:
  - `clear-action-cache.yaml`
  - `openssf-scorecard.yaml`

All repository-specific content (the comprehensive `testing.yaml` suite, the
`input-validation.yaml` security tests, and the zizmor hardening already merged
in #114) is preserved untouched.

## Dependabot

The only relevant ecosystem here is `github-actions` (this is a composite
action driven by shell scripts — no `go.mod`, Python manifest, or `Dockerfile`
to track). Aligned the existing config with the template:

- Switch the `github-actions` commit prefix to `CI(actions)`.
- Document the cooldown rationale (zizmor requirement).
- Add an explicit `open-pull-requests-limit: 15`.

## Fixes

- Correct a typo in `.editorconfig` (`max_line_legth` → `max_line_length`) that
  was silently disabling the 120-character limit for `[*.py]`.

## Validation

- `yamllint`: clean
- `actionlint`: clean
- Full local `pre-commit` suite: passing (gitlint, reuse, codespell,
  check-jsonschema workflow validation, etc.)

## Note for reviewers

`testing.yaml` and `input-validation.yaml` perform heavy network I/O (Docker
image pulls, `http-api-tool-docker`). With `egress-policy: block`, anything not
in the org allow-list will be blocked — worth watching the first CI run after
merge in case the central allow-list needs an addition.

Co-authored-by: Claude <claude@anthropic.com>