### PR TITLE
Fix: detect host gateway without Docker Hub pull

### DIFF
--- a/.github/workflows/clear-action-cache.yaml
+++ b/.github/workflows/clear-action-cache.yaml
@@ -55,7 +55,7 @@ jobs:
       # yamllint disable-line rule:line-length
       - uses: lfreleng-actions/harden-runner-block-action@42663a22f7abe31521cbc6120901353a4b2849bc  # v0.2.0
         with:
-          config: '@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+          config: '@aa81113fe43792f29f939c79ea47a04801cf5342'  # v0.4.1
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'

--- a/.github/workflows/clear-action-cache.yaml
+++ b/.github/workflows/clear-action-cache.yaml
@@ -47,7 +47,7 @@ jobs:
     timeout-minutes: 10
     permissions:
       # Actions cache deletion requires the actions: write scope.
-      actions: write
+      actions: write  # Required to delete Actions cache entries.
     steps:
       # Load the egress allow-list out-of-band from the
       # organisation's .github repository and publish it as
@@ -72,11 +72,13 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           KEY_PATTERN: ${{ inputs.key_pattern }}
           REF_FILTER: ${{ inputs.ref_filter }}
+          INPUTS_DRY_RUN: ${{ inputs.dry_run }}
+          REPOSITORY: ${{ github.repository }}
         run: |
           # List current cache entries (pre-deletion snapshot).
           set -euo pipefail
 
-          echo "Repository: ${{ github.repository }}"
+          echo "Repository: ${REPOSITORY}"
           echo "Key filter: '${KEY_PATTERN:-<none>}'"
           echo "Ref filter: '${REF_FILTER:-<none>}'"
           echo ""
@@ -88,7 +90,7 @@ jobs:
             gh api \
               --paginate \
               -H "Accept: application/vnd.github+json" \
-              "/repos/${{ github.repository }}/actions/caches?per_page=100" \
+              "/repos/${REPOSITORY}/actions/caches?per_page=100" \
               --jq '.actions_caches[]'
           )
 
@@ -141,7 +143,7 @@ jobs:
             echo "|----------|-------|"
             echo "| Total entries | $before_count |"
             echo "| Matched | $matched_count |"
-            echo "| Dry run | \`${{ inputs.dry_run }}\` |"
+            echo "| Dry run | \`${INPUTS_DRY_RUN}\` |"
             echo ""
             # Render user-controlled filter inputs inside a fenced
             # code block. KEY_PATTERN and REF_FILTER are free-form
@@ -185,6 +187,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           DRY_RUN: ${{ inputs.dry_run }}
+          REPOSITORY: ${{ github.repository }}
         run: |
           # Delete the matched cache IDs unless this is a dry run.
           set -euo pipefail
@@ -216,7 +219,7 @@ jobs:
             if gh api \
                 --method DELETE \
                 -H "Accept: application/vnd.github+json" \
-                "/repos/${{ github.repository }}/actions/caches/${cache_id}";
+                "/repos/${REPOSITORY}/actions/caches/${cache_id}";
             then
               deleted=$((deleted + 1))
             else
@@ -252,6 +255,7 @@ jobs:
           KEY_PATTERN: ${{ inputs.key_pattern }}
           REF_FILTER: ${{ inputs.ref_filter }}
           DRY_RUN: ${{ inputs.dry_run }}
+          REPOSITORY: ${{ github.repository }}
         run: |
           # Re-query the cache list and confirm matched entries are
           # gone (or still present in dry-run mode).
@@ -261,7 +265,7 @@ jobs:
             gh api \
               --paginate \
               -H "Accept: application/vnd.github+json" \
-              "/repos/${{ github.repository }}/actions/caches?per_page=100" \
+              "/repos/${REPOSITORY}/actions/caches?per_page=100" \
               --jq '.actions_caches[]'
           )
 

--- a/.github/workflows/input-validation.yaml
+++ b/.github/workflows/input-validation.yaml
@@ -33,7 +33,7 @@ jobs:
       # yamllint disable-line rule:line-length
       - uses: lfreleng-actions/harden-runner-block-action@42663a22f7abe31521cbc6120901353a4b2849bc  # v0.2.0
         with:
-          config: '@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+          config: '@aa81113fe43792f29f939c79ea47a04801cf5342'  # v0.4.1
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'

--- a/.github/workflows/input-validation.yaml
+++ b/.github/workflows/input-validation.yaml
@@ -115,14 +115,17 @@ jobs:
 
       - name: 'Generate Test Report'
         if: always()
+        env:
+          RUN_ID: ${{ github.run_id }}
+          COMMIT_SHA: ${{ github.sha }}
         run: |
           {
             echo "## Input Validation Test Report"
             echo ""
             echo "**Test Run**: $(date)"
             echo "**Workflow**: ${GITHUB_WORKFLOW}"
-            echo "**Run ID**: ${{ github.run_id }}"
-            echo "**Commit**: ${{ github.sha }}"
+            echo "**Run ID**: ${RUN_ID}"
+            echo "**Commit**: ${COMMIT_SHA}"
             echo ""
           } > test-report.md
 

--- a/.github/workflows/openssf-scorecard.yaml
+++ b/.github/workflows/openssf-scorecard.yaml
@@ -30,11 +30,8 @@ jobs:
     # yamllint disable-line rule:line-length
     uses: lfit/releng-reusable-workflows/.github/workflows/reuse-openssf-scorecard.yaml@50e324ef804880c13d4aebcefcac07ad81661d01  # v0.6.1
     permissions:
-      # Needed to read repository contents (checkout, etc.).
-      contents: read
-      # Needed to upload the results to the code-scanning dashboard.
-      security-events: write
-      # Needed to publish results and obtain a Scorecard badge via OIDC.
-      id-token: write
+      contents: read  # Needed to read repository contents (checkout, etc.).
+      security-events: write  # Needed to upload results to code-scanning.
+      id-token: write  # Needed to publish results / Scorecard badge via OIDC.
       # Uncomment the permission below if installing in a private repository.
       # actions: read

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -21,7 +21,7 @@ jobs:
     name: 'Update Release Draft'
     permissions:
       # write permission is required to create releases
-      contents: write
+      contents: write  # Required to create/update draft releases.
     runs-on: 'ubuntu-latest'
     timeout-minutes: 3
     steps:

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -31,7 +31,7 @@ jobs:
       # yamllint disable-line rule:line-length
       - uses: lfreleng-actions/harden-runner-block-action@42663a22f7abe31521cbc6120901353a4b2849bc  # v0.2.0
         with:
-          config: '@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+          config: '@aa81113fe43792f29f939c79ea47a04801cf5342'  # v0.4.1
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'

--- a/.github/workflows/tag-push.yaml
+++ b/.github/workflows/tag-push.yaml
@@ -11,6 +11,13 @@ on:
     tags:
       - '**'
 
+# Serialise tag/release promotion runs. Do NOT cancel in-progress
+# runs: aborting a release promotion mid-flight could leave a draft
+# release in an inconsistent state.
+concurrency:
+  group: 'tag-push-${{ github.ref }}'
+  cancel-in-progress: false
+
 permissions: {}
 
 jobs:
@@ -64,7 +71,7 @@ jobs:
     needs: validate_tag
     runs-on: 'ubuntu-latest'
     permissions:
-      contents: write
+      contents: write  # Required to promote/publish the draft release.
     timeout-minutes: 5
     steps:
       # Load the egress allow-list out-of-band from the

--- a/.github/workflows/tag-push.yaml
+++ b/.github/workflows/tag-push.yaml
@@ -31,7 +31,7 @@ jobs:
       # yamllint disable-line rule:line-length
       - uses: lfreleng-actions/harden-runner-block-action@42663a22f7abe31521cbc6120901353a4b2849bc  # v0.2.0
         with:
-          config: '@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+          config: '@aa81113fe43792f29f939c79ea47a04801cf5342'  # v0.4.1
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'
@@ -73,7 +73,7 @@ jobs:
       # yamllint disable-line rule:line-length
       - uses: lfreleng-actions/harden-runner-block-action@42663a22f7abe31521cbc6120901353a4b2849bc  # v0.2.0
         with:
-          config: '@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+          config: '@aa81113fe43792f29f939c79ea47a04801cf5342'  # v0.4.1
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -40,7 +40,7 @@ jobs:
       # yamllint disable-line rule:line-length
       - uses: lfreleng-actions/harden-runner-block-action@42663a22f7abe31521cbc6120901353a4b2849bc  # v0.2.0
         with:
-          config: '@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+          config: '@aa81113fe43792f29f939c79ea47a04801cf5342'  # v0.4.1
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'
@@ -133,18 +133,12 @@ jobs:
           echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
           echo "🔌 Container-to-Host Networking"
           echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-          echo "Testing from another container (simulates http-api-tool-docker):"
-
-          docker run --rm alpine sh -c "
-            apk add --no-cache curl >/dev/null 2>&1
-            echo -n 'Gateway IP (${{ steps.httpbin-basic.outputs.host-gateway-ip }}:8080)... '
-            if curl -s -k --max-time 2 https://${{ steps.httpbin-basic.outputs.host-gateway-ip }}:8080/get > /dev/null 2>&1; then
-              echo '✅'
-            else
-              echo '❌'
-              exit 1
-            fi
-          "
+          # Container-to-host reachability via the gateway IP is exercised
+          # for real by the http-api-tool-docker steps below (each runs in a
+          # container and connects to the service). We avoid a throwaway
+          # "docker run alpine" probe here so service setup does not depend on
+          # a Docker Hub pull, which is unreliable on egress-hardened runners.
+          echo "Covered by the http-api-tool-docker steps that follow."
           echo ""
           echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -53,6 +53,8 @@ jobs:
 
       - name: 'Checkout repository'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       # =================================================================
       # BASIC HTTPS TESTS
@@ -71,10 +73,10 @@ jobs:
           echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
           echo "🔍 Service Configuration"
           echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-          echo "Service URL: ${{ steps.httpbin-basic.outputs.service-url }}"
-          echo "Host Gateway IP: ${{ steps.httpbin-basic.outputs.host-gateway-ip }}"
-          echo "Protocol: ${{ steps.httpbin-basic.outputs.protocol }}"
-          echo "Container: ${{ steps.httpbin-basic.outputs.container-name }}"
+          echo "Service URL: ${STEPS_HTTPBIN_BASIC_OUTPUTS_SERVICE_URL}"
+          echo "Host Gateway IP: ${STEPS_HTTPBIN_BASIC_OUTPUTS_HOST_GATEWAY_IP}"
+          echo "Protocol: ${STEPS_HTTPBIN_BASIC_OUTPUTS_PROTOCOL}"
+          echo "Container: ${STEPS_HTTPBIN_BASIC_OUTPUTS_CONTAINER_NAME}"
           echo ""
 
           echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
@@ -89,12 +91,12 @@ jobs:
           fi
           echo ""
 
-          STATUS=$(docker inspect ${{ steps.httpbin-basic.outputs.container-name }} --format='{{.State.Status}}' 2>/dev/null || echo "unknown")
+          STATUS=$(docker inspect "${STEPS_HTTPBIN_BASIC_OUTPUTS_CONTAINER_NAME}" --format='{{.State.Status}}' 2>/dev/null || echo "unknown")
           if [ "$STATUS" = "running" ]; then
             echo "✅ Container status: $STATUS"
           else
             echo "❌ Container status: $STATUS"
-            docker logs ${{ steps.httpbin-basic.outputs.container-name }} 2>&1 | tail -10
+            docker logs "${STEPS_HTTPBIN_BASIC_OUTPUTS_CONTAINER_NAME}" 2>&1 | tail -10
             exit 1
           fi
           echo ""
@@ -112,16 +114,16 @@ jobs:
           fi
 
           # Test gateway IP (should work for container-to-container communication)
-          echo -n "Testing gateway IP (${{ steps.httpbin-basic.outputs.host-gateway-ip }}:8080)... "
-          if curl -s -k --max-time 3 https://${{ steps.httpbin-basic.outputs.host-gateway-ip }}:8080/get > /dev/null 2>&1; then
+          echo -n "Testing gateway IP (${STEPS_HTTPBIN_BASIC_OUTPUTS_HOST_GATEWAY_IP}:8080)... "
+          if curl -s -k --max-time 3 "https://${STEPS_HTTPBIN_BASIC_OUTPUTS_HOST_GATEWAY_IP}:8080/get" > /dev/null 2>&1; then
             echo "✅"
           else
             echo "❌"
           fi
 
           # Test service URL (this is what the action outputs)
-          echo -n "Testing service URL (${{ steps.httpbin-basic.outputs.service-url }})... "
-          if curl -s -k --max-time 3 ${{ steps.httpbin-basic.outputs.service-url }}/get > /dev/null 2>&1; then
+          echo -n "Testing service URL (${STEPS_HTTPBIN_BASIC_OUTPUTS_SERVICE_URL})... "
+          if curl -s -k --max-time 3 "${STEPS_HTTPBIN_BASIC_OUTPUTS_SERVICE_URL}/get" > /dev/null 2>&1; then
             echo "✅"
           else
             echo "❌"
@@ -141,6 +143,11 @@ jobs:
           echo "Covered by the http-api-tool-docker steps that follow."
           echo ""
           echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+        env:
+          STEPS_HTTPBIN_BASIC_OUTPUTS_SERVICE_URL: ${{ steps.httpbin-basic.outputs.service-url }}
+          STEPS_HTTPBIN_BASIC_OUTPUTS_HOST_GATEWAY_IP: ${{ steps.httpbin-basic.outputs.host-gateway-ip }}
+          STEPS_HTTPBIN_BASIC_OUTPUTS_PROTOCOL: ${{ steps.httpbin-basic.outputs.protocol }}
+          STEPS_HTTPBIN_BASIC_OUTPUTS_CONTAINER_NAME: ${{ steps.httpbin-basic.outputs.container-name }}
 
       - name: 'Basic HTTPS Test - Simple GET request'
         uses: lfreleng-actions/http-api-tool-docker@12a062c2289831b79166269340ffb44fa2c113e9 # v1.0.7
@@ -207,8 +214,10 @@ jobs:
 
       - name: 'Stop basic HTTPS service'
         run: |
-          docker stop ${{ steps.httpbin-basic.outputs.container-name }}
-          docker rm ${{ steps.httpbin-basic.outputs.container-name }}
+          docker stop "${STEPS_HTTPBIN_BASIC_OUTPUTS_CONTAINER_NAME}"
+          docker rm "${STEPS_HTTPBIN_BASIC_OUTPUTS_CONTAINER_NAME}"
+        env:
+          STEPS_HTTPBIN_BASIC_OUTPUTS_CONTAINER_NAME: ${{ steps.httpbin-basic.outputs.container-name }}
 
       # =================================================================
       # HTTP (NO SSL) TESTS
@@ -255,8 +264,10 @@ jobs:
 
       - name: 'Stop HTTP service'
         run: |
-          docker stop ${{ steps.httpbin-http.outputs.container-name }}
-          docker rm ${{ steps.httpbin-http.outputs.container-name }}
+          docker stop "${STEPS_HTTPBIN_HTTP_OUTPUTS_CONTAINER_NAME}"
+          docker rm "${STEPS_HTTPBIN_HTTP_OUTPUTS_CONTAINER_NAME}"
+        env:
+          STEPS_HTTPBIN_HTTP_OUTPUTS_CONTAINER_NAME: ${{ steps.httpbin-http.outputs.container-name }}
 
       # =================================================================
       # CUSTOM PORT TESTS
@@ -306,7 +317,9 @@ jobs:
 
       - name: 'Stop custom port service'
         run: |
-          docker stop ${{ steps.httpbin-custom-port.outputs.container-name }}
+          docker stop "${STEPS_HTTPBIN_CUSTOM_PORT_OUTPUTS_CONTAINER_NAME}"
+        env:
+          STEPS_HTTPBIN_CUSTOM_PORT_OUTPUTS_CONTAINER_NAME: ${{ steps.httpbin-custom-port.outputs.container-name }}
 
       # =================================================================
       # HOST NETWORK TESTS
@@ -352,7 +365,9 @@ jobs:
 
       - name: 'Stop host network service'
         run: |
-          docker stop ${{ steps.httpbin-host-network.outputs.container-name }}
+          docker stop "${STEPS_HTTPBIN_HOST_NETWORK_OUTPUTS_CONTAINER_NAME}"
+        env:
+          STEPS_HTTPBIN_HOST_NETWORK_OUTPUTS_CONTAINER_NAME: ${{ steps.httpbin-host-network.outputs.container-name }}
 
       # =================================================================
       # ADVANCED FEATURES TESTS
@@ -707,7 +722,9 @@ jobs:
 
       - name: 'Stop comprehensive test service'
         run: |
-          docker stop ${{ steps.httpbin-comprehensive.outputs.container-name }}
+          docker stop "${STEPS_HTTPBIN_COMPREHENSIVE_OUTPUTS_CONTAINER_NAME}"
+        env:
+          STEPS_HTTPBIN_COMPREHENSIVE_OUTPUTS_CONTAINER_NAME: ${{ steps.httpbin-comprehensive.outputs.container-name }}
 
       # =================================================================
       # ERROR HANDLING AND EDGE CASES TESTS
@@ -771,4 +788,6 @@ jobs:
         run: |
           echo "🧪 All test scenarios completed!"
           echo "Stopping final test service..."
-          docker stop ${{ steps.httpbin-error.outputs.container-name }}
+          docker stop "${STEPS_HTTPBIN_ERROR_OUTPUTS_CONTAINER_NAME}"
+        env:
+          STEPS_HTTPBIN_ERROR_OUTPUTS_CONTAINER_NAME: ${{ steps.httpbin-error.outputs.container-name }}

--- a/action.yaml
+++ b/action.yaml
@@ -309,9 +309,36 @@ runs:
           echo "Successfully installed mkcert: $INSTALLED_VERSION"
         fi
 
-        # Get Docker host gateway IP for container-to-host communication
-        HOST_GATEWAY=$(docker run --rm alpine sh -c \
-          "ip route | grep '^default' | cut -d' ' -f3")
+        # Get Docker host gateway IP for container-to-host communication.
+        # Read it directly from the default bridge network rather than
+        # pulling an image and running a container. Pulling from Docker Hub
+        # is unreliable under egress-hardened runners (the CDN/registry IPs
+        # rotate and may not match an allow-listed hostname), and it adds an
+        # unnecessary network dependency to service setup.
+        # Emit one gateway per line and select the first IPv4 address, so a
+        # bridge with multiple IPAM configs (e.g. IPv4 + IPv6) cannot yield a
+        # concatenated, invalid value.
+        HOST_GATEWAY=$(docker network inspect bridge \
+          --format '{{range .IPAM.Config}}{{println .Gateway}}{{end}}' \
+          2>/dev/null | grep -Em1 '^[0-9]+(\.[0-9]+){3}$' || true)
+        if [[ -z "$HOST_GATEWAY" ]]; then
+          # Fall back to the docker0 bridge interface address on the host;
+          # the interface's own IPv4 address is the bridge gateway. Validate
+          # it as IPv4 (mirroring the bridge lookup) so transient route/link
+          # state text such as 'linkdown' cannot yield a non-IP value. The
+          # '|| true' keeps a missing docker0 interface (rootless/custom
+          # setups) from tripping 'set -e' via pipefail, so the explicit
+          # guard below reports a clear error instead.
+          HOST_GATEWAY=$(ip -4 -o addr show docker0 2>/dev/null \
+            | awk '{print $4}' | cut -d/ -f1 \
+            | grep -Em1 '^[0-9]+(\.[0-9]+){3}$' || true)
+        fi
+        if [[ -z "$HOST_GATEWAY" ]]; then
+          echo "ERROR: Could not determine the Docker host gateway IP" >&2
+          echo "Inspected the default 'bridge' network and the docker0" >&2
+          echo "interface; both yielded no IPv4 gateway address." >&2
+          exit 1
+        fi
         echo "Docker host gateway IP: $HOST_GATEWAY"
 
         # Setup local CA and certificates if not skipped


### PR DESCRIPTION
## Problem

The Comprehensive Test Suite failed during service setup while fetching the
`alpine` image from Docker Hub:

```
docker: error pulling image configuration: download failed after attempts=6:
dial tcp 54.185.253.63:443: connect: connection refused
```

The local action (`action.yaml`) read the Docker host gateway IP by running a
throwaway `docker run --rm alpine` container purely to inspect its default
route. Under `step-security/harden-runner` block mode, that pull is blocked: the
allow_list revision pinned by these workflows (v0.1.1) predates the Docker Hub
pull/push CDN host (`production.cloudfront.docker.com`), so the blob download is
refused. Pulling an image just to read the gateway is also an unnecessary
network dependency.

## Changes

### `action.yaml` — remove the Docker Hub dependency
- Read the host gateway directly from the default bridge network via
  `docker network inspect bridge`, with a fallback to the `docker0` interface.
  No image pull, and it works under any egress policy.
- Select the **first IPv4** gateway (one address per line via `println`, then
  `grep`), so a bridge with multiple IPAM configs (e.g. IPv4 + IPv6, or multiple
  subnets) cannot yield a concatenated, invalid value.
- **Fail explicitly** with a clear error if no gateway can be determined, rather
  than letting an empty value propagate into `cert_domains`/`SERVICE_URL` and
  produce confusing downstream failures like `https://:8080`.

### `.github/workflows/testing.yaml` — drop the redundant probe
- Remove the `docker run --rm alpine` container-to-host probe. The
  `http-api-tool-docker` steps that follow already exercise container-to-host
  reachability for real (each runs in a container and connects to the service),
  so no coverage is lost.

### Workflows — bump the allow_list pin (hygiene)
- Bump the `harden-runner-block-action` `config:` pin from **v0.1.1** to
  **v0.4.1** across all workflows. v0.4.1 includes
  `production.cloudfront.docker.com`, so any *future* Docker Hub egress is
  covered. Not required by the gateway fix above, but keeps the pinned egress
  policy current.

### Workflows — resolve zizmor security-audit findings (hygiene)
Ran `zizmor` in **full auditor mode** across every workflow and `action.yaml`
and resolved all reported findings (audit is now clean):

- **template-injection**: hoist `${{ ... }}` expansions used inside `run:`
  blocks into quoted `env:` variables (`github.repository`, `github.run_id`,
  `github.sha`, and step outputs), so expansions can never be interpreted as
  shell code. Affects `testing.yaml`, `clear-action-cache.yaml`, and
  `input-validation.yaml`.
- **artipacked**: add `persist-credentials: false` to the `testing.yaml`
  checkout so the job token is not left behind in `.git/config`.
- **undocumented-permissions**: add inline explanatory comments on each granted
  permission scope (`clear-action-cache.yaml`, `openssf-scorecard.yaml`,
  `release-drafter.yaml`, `tag-push.yaml`).
- **concurrency-limits**: add a `concurrency:` group to `tag-push.yaml`.
  `cancel-in-progress` is deliberately **false** — this workflow promotes draft
  releases, and cancelling a run mid-flight could leave a release in an
  inconsistent state.

## Validation

- `prek run` over the changed files passes (yamllint, actionlint, GitHub
  Actions/Workflows validation incl. SHA-pinning, codespell, reuse).
- `zizmor --persona=auditor` reports **no findings** across all workflows and
  `action.yaml`.
- The new gateway pipeline was verified locally under `set -euo pipefail`
  (returns `172.17.0.1`).
- The service image (`ghcr.io/mccutchen/go-httpbin`) is already allow-listed on
  GHCR, so the action has no remaining Docker Hub dependency in its setup path.
